### PR TITLE
RDI-2895 RDI-2873 Add CopyLastReconFrame to expose last reconstructed YUV frame

### DIFF
--- a/codec/api/wels/codec_api.h
+++ b/codec/api/wels/codec_api.h
@@ -309,6 +309,29 @@ class ISVCEncoder {
   virtual int EXTAPI EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo) = 0;
 
   /**
+  * @brief Copy the reconstructed YUV frame of the last encoded picture.
+  *
+  * Copies the reconstructed frame data (Y, U, V planes in I420 format) from the encoder's internal buffer
+  * for the most recently encoded frame into user-provided output buffers. This is useful for applications
+  * that require direct access to the raw image, such as real-time preview, quality analysis, or further processing.
+  *
+  * @param pSrcPic Pointer to the ~SSourcePicture~ structure describing the frame layout and dimensions.
+  * @param pData Array of pointers to output buffers for each plane:
+  *        + ~pData[0]~: Y (luma) data buffer pointer
+  *        + ~pData[1]~: U (chroma) data buffer pointer
+  *        + ~pData[2]~: V (chroma) data buffer pointer
+  *        The buffers must be allocated by the caller and be large enough to hold the frame data.
+  * @return ~0~ on success; otherwise, a non-zero error code if the operation fails (e.g., feature not enabled, invalid buffers).
+  *
+  * @note
+  * + The encoder must be initialized with ~ENCODER_OPTION_ENABLE_LAST_RECON_FRAME~ set to ~true~.
+  * + The reconstructed frame is in I420 (YUV 4:2:0 planar) format.
+  * + This function does not encode or decode; it only copies the internal buffer to user memory.
+  * + Typical use cases include preview, PSNR/SSIM calculation, or integration with video pipelines needing raw YUV frames.
+  */
+  virtual int EXTAPI CopyLastReconFrame (SSourcePicture* pSrcPic, unsigned char* pData[3]) = 0;
+
+  /**
   * @brief  Encode the parameters from output bit stream
   * @param  pBsInfo output bit stream
   * @return 0 - success; otherwise - failed;

--- a/codec/api/wels/codec_app_def.h
+++ b/codec/api/wels/codec_app_def.h
@@ -142,7 +142,9 @@ typedef enum {
 
   ENCODER_OPTION_IS_LOSSLESS_LINK,            ///< advanced algorithmetic settings
 
-  ENCODER_OPTION_BITS_VARY_PERCENTAGE        ///< bit vary percentage
+  ENCODER_OPTION_BITS_VARY_PERCENTAGE,       ///< bit vary percentage
+
+  ENCODER_OPTION_ENABLE_LAST_RECON_FRAME     ///< enable access last frame recon for app layer
 } ENCODER_OPTION;
 
 /**

--- a/codec/encoder/core/inc/encoder.h
+++ b/codec/encoder/core/inc/encoder.h
@@ -101,6 +101,11 @@ extern "C" void DumpDependencyRec (SPicture* pSrcPic, const char* kpFileName, co
  */
 void DumpRecFrame (SPicture* pSrcPic, const char* kpFileName, const int8_t kiDid, bool bAppend, SDqLayer* pDqLayer);
 
+/*!
+ * \brief   copy the reconstruction frame to the output buffers
+ */
+void SaveLastReconFrame (SPicture* pCurPicture, sWelsEncCtx* pEncCtx, SDqLayer* pDqLayer);
+
 
 /*!
  * \brief   encode overall slices pData in a frame

--- a/codec/encoder/core/inc/encoder_context.h
+++ b/codec/encoder/core/inc/encoder_context.h
@@ -235,6 +235,9 @@ typedef struct TagWelsEncCtx {
 #endif
   int64_t            uiLastTimestamp;
   uint8_t*           pDynamicBsBuffer[MAX_THREADS_NUM];
+
+  bool               bEnableLastReconFrame; // indicate whether enable the output of last recon frame
+  unsigned char*     pLastReconFrame[3];    // YUV data for last recon frame
 } sWelsEncCtx/*, *PWelsEncCtx*/;
 }
 #endif//sWelsEncCtx_H__

--- a/codec/encoder/core/inc/extern.h
+++ b/codec/encoder/core/inc/extern.h
@@ -94,6 +94,7 @@ void WelsUninitEncoderExt (sWelsEncCtx** ppCtx);
  * \return  EFrameType (videoFrameTypeIDR/videoFrameTypeI/videoFrameTypeP)
  */
 int32_t WelsEncoderEncodeExt (sWelsEncCtx*, SFrameBSInfo* pFbi, const SSourcePicture* kpSrcPic);
+int32_t WelsEncoderCopyLastReconFrame (sWelsEncCtx* pCtx, SSourcePicture* pSrcPic, unsigned char* pDst[3]);
 
 int32_t WelsEncoderEncodeParameterSets (sWelsEncCtx* pCtx, void* pDst);
 

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -544,6 +544,52 @@ void DumpRecFrame (SPicture* pCurPicture, const char* kpFileName, const int8_t k
   }
 }
 
+void SaveLastReconFrame (SPicture* pCurPicture, sWelsEncCtx* pEncCtx, SDqLayer* pDqLayer) {
+  if (pEncCtx->bEnableLastReconFrame) {
+    SWelsSPS* pSpsTmp = pDqLayer->sLayerInfo.pSpsP;
+    bool bFrameCroppingFlag = pSpsTmp->bFrameCroppingFlag;
+    SCropOffset* pFrameCrop = &pSpsTmp->sFrameCrop;
+
+    const int32_t kiStrideY      = pCurPicture->iLineSize[0];
+    const int32_t kiLumaWidth    = bFrameCroppingFlag ? (pCurPicture->iWidthInPixel - ((pFrameCrop->iCropLeft +
+                                   pFrameCrop->iCropRight) << 1)) : pCurPicture->iWidthInPixel;
+    const int32_t kiLumaHeight   = bFrameCroppingFlag ? (pCurPicture->iHeightInPixel - ((pFrameCrop->iCropTop +
+                                   pFrameCrop->iCropBottom) << 1)) : pCurPicture->iHeightInPixel;
+    const int32_t kiChromaWidth  = kiLumaWidth >> 1;
+    const int32_t kiChromaHeight = kiLumaHeight >> 1;
+    const int32_t kiLumaSize = kiLumaWidth * kiLumaHeight;
+    const int32_t kiChromaSize = kiChromaWidth * kiChromaHeight;
+
+    if (NULL == pEncCtx->pLastReconFrame[0]) {
+      CMemoryAlign* pMa = pEncCtx->pMemAlign;
+
+      pEncCtx->pLastReconFrame[0] = (unsigned char*) pMa->WelsMallocz (kiLumaSize +
+                                    (kiChromaSize << 1), "pLastReconFrame");
+      pEncCtx->pLastReconFrame[1] = pEncCtx->pLastReconFrame[0] + kiLumaSize;
+      pEncCtx->pLastReconFrame[2] = pEncCtx->pLastReconFrame[1] + kiChromaSize;
+    }
+
+    if (NULL != pEncCtx->pLastReconFrame[0]) {
+      // Copy Y plane
+      unsigned char* pSrcY = bFrameCroppingFlag ? (pCurPicture->pData[0] + kiStrideY * (pFrameCrop->iCropTop << 1) +
+                             (pFrameCrop->iCropLeft << 1)) : pCurPicture->pData[0];
+      for (int32_t j = 0; j < kiLumaHeight; ++j) {
+        memcpy (pEncCtx->pLastReconFrame[0] + j * kiLumaWidth, pSrcY + j * kiStrideY, kiLumaWidth);
+      }
+
+      // Copy U and V planes
+      for (int i = 1; i < 3; ++i) {
+        const int32_t kiStrideUV = pCurPicture->iLineSize[i];
+        unsigned char* pSrcUV = bFrameCroppingFlag ? (pCurPicture->pData[i] + kiStrideUV * pFrameCrop->iCropTop +
+                                pFrameCrop->iCropLeft)
+                                : pCurPicture->pData[i];
+        for (int32_t j = 0; j < kiChromaHeight; ++j) {
+          memcpy (pEncCtx->pLastReconFrame[i] + j * kiChromaWidth, pSrcUV + j * kiStrideUV, kiChromaWidth);
+        }
+      }
+    }
+  }
+}
 
 
 /***********************************************************************************/

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -1983,6 +1983,13 @@ void FreeMemorySvc (sWelsEncCtx** ppCtx) {
       pCtx->pMvdCostTable = NULL;
     }
 
+    if (NULL != pCtx->pLastReconFrame[0]) {
+      pMa->WelsFree (pCtx->pLastReconFrame[0], "pLastReconFrame");
+      pCtx->pLastReconFrame[0] = NULL;
+      pCtx->pLastReconFrame[1] = NULL;
+      pCtx->pLastReconFrame[2] = NULL;
+    }
+
     FreeCodingParam (&pCtx->pSvcParam, pMa);
     if (NULL != pCtx->pFuncList) {
       if (NULL != pCtx->pFuncList->pParametersetStrategy) {
@@ -2374,6 +2381,7 @@ int32_t WelsInitEncoderExt (sWelsEncCtx** ppCtx, SWelsSvcCodingParam* pCodingPar
   pCtx->iStatisticsLogInterval = STATISTICS_LOG_INTERVAL_MS;
   pCtx->uiLastTimestamp = -1;
   pCtx->bDeliveryFlag = true;
+  pCtx->bEnableLastReconFrame = false;
   *ppCtx = pCtx;
 
   WelsLog (pLogCtx, WELS_LOG_INFO, "WelsInitEncoderExt(), pCtx= 0x%p.", (void*)pCtx);
@@ -3914,6 +3922,10 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
       pCtx->bDependencyRecFlag[iCurDid] = true;
     }
 #endif//ENABLE_FRAME_DUMP
+
+    if (iSpatialNum == 1) {
+      SaveLastReconFrame (fsnr, pCtx, pCtx->pCurDqLayer);
+    }
 
     if (fsnr && (pSvcParam->bPsnrY || pSrcPic->bPsnrY)) {
       fSnrY = WelsCalcPsnr (fsnr->pData[0],

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -4178,6 +4178,29 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
   return ENC_RETURN_SUCCESS;
 }
 
+int32_t WelsEncoderCopyLastReconFrame (sWelsEncCtx* pCtx, SSourcePicture* pSrcPic, unsigned char* pDst[3]) {
+  if (!pSrcPic || !pDst)
+    return ENC_RETURN_INVALIDINPUT;
+  if (!pCtx->bEnableLastReconFrame) {
+    WelsLog (& pCtx->sLogCtx, WELS_LOG_ERROR, "WelsEncoderCopyLastReconFrame(), last recon frame not enabled!");
+    return ENC_RETURN_UNEXPECTED;
+  }
+  if (!pCtx->pLastReconFrame[0]) {
+    WelsLog (& pCtx->sLogCtx, WELS_LOG_ERROR, "WelsEncoderCopyLastReconFrame(), last recon frame buffer not allocated!");
+    return ENC_RETURN_UNEXPECTED;
+  }
+
+  for (int stride = 0; stride < 3; stride++) {
+    if (pSrcPic->iStride[stride] == 0 || pDst[stride] == NULL)
+      continue;
+    for (int32_t i = 0; i < pSrcPic->iPicHeight; i++)
+      memcpy (pDst[stride] + i * pSrcPic->iStride[stride],
+              pCtx->pLastReconFrame[stride] + i * pSrcPic->iPicWidth, pSrcPic->iPicWidth);
+  }
+
+  return ENC_RETURN_SUCCESS;
+}
+
 /*!
  * \brief   Wels SVC encoder parameters adjustment
  *          SVC adjustment results in new requirement in memory blocks adjustment

--- a/codec/encoder/plus/inc/welsEncoderExt.h
+++ b/codec/encoder/plus/inc/welsEncoderExt.h
@@ -76,6 +76,7 @@ class CWelsH264SVCEncoder : public ISVCEncoder {
    * return: 0 - success; otherwise - failed;
    */
   virtual int EXTAPI EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
+  virtual int EXTAPI CopyLastReconFrame (SSourcePicture* pSrcPic, unsigned char* pData[3]);
   virtual int        EncodeFrameInternal (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
 
   /*

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -1185,6 +1185,13 @@ int CWelsH264SVCEncoder::SetOption (ENCODER_OPTION eOptionId, void* pOption) {
              "CWelsH264SVCEncoder::SetOption():ENCODER_OPTION_BITS_VARY_PERCENTAGE,iBitsVaryPercentage = %d", iValue);
   }
   break;
+  case ENCODER_OPTION_ENABLE_LAST_RECON_FRAME: {
+    bool bValue = * (static_cast<bool*> (pOption));
+    m_pEncContext->bEnableLastReconFrame = bValue;
+    WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_INFO,
+             "CWelsH264SVCEncoder::SetOption():ENCODER_OPTION_ENABLE_LAST_RECON_FRAME,bEnableLastReconFrame = %d", bValue);
+  }
+  break;
 
   default:
     return cmInitParaError;
@@ -1299,6 +1306,10 @@ int CWelsH264SVCEncoder::GetOption (ENCODER_OPTION eOptionId, void* pOption) {
   break;
   case ENCODER_OPTION_COMPLEXITY: {
     * ((int32_t*)pOption) =  m_pEncContext->pSvcParam->iComplexityMode;
+  }
+  break;
+  case ENCODER_OPTION_ENABLE_LAST_RECON_FRAME: {
+    * ((bool*)pOption) = m_pEncContext->bEnableLastReconFrame;
   }
   break;
   default:

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -477,6 +477,10 @@ int CWelsH264SVCEncoder ::EncodeFrameInternal (const SSourcePicture*  pSrcPic, S
 
 }
 
+int CWelsH264SVCEncoder::CopyLastReconFrame (SSourcePicture* pSrcPic, unsigned char* pDst[3]) {
+  return WelsEncoderCopyLastReconFrame (m_pEncContext, pSrcPic, pDst);
+}
+
 int CWelsH264SVCEncoder::EncodeParameterSets (SFrameBSInfo* pBsInfo) {
   return WelsEncoderEncodeParameterSets (m_pEncContext, pBsInfo);
 }

--- a/test/api/cpp_interface_test.cpp
+++ b/test/api/cpp_interface_test.cpp
@@ -43,21 +43,26 @@ struct SVCEncoderImpl : public ISVCEncoder {
     EXPECT_TRUE (gThis == this);
     return 5;
   }
-  virtual int EXTAPI EncodeParameterSets (SFrameBSInfo* pBsInfo) {
+  virtual int EXTAPI CopyLastReconFrame (SSourcePicture* pSrcPic,
+                                         unsigned char* pData[3]) {
     EXPECT_TRUE (gThis == this);
     return 6;
   }
-  virtual int EXTAPI ForceIntraFrame (bool bIDR, int iLayerId = -1) {
+  virtual int EXTAPI EncodeParameterSets (SFrameBSInfo* pBsInfo) {
     EXPECT_TRUE (gThis == this);
     return 7;
   }
-  virtual int EXTAPI SetOption (ENCODER_OPTION eOptionId, void* pOption) {
+  virtual int EXTAPI ForceIntraFrame (bool bIDR, int iLayerId = -1) {
     EXPECT_TRUE (gThis == this);
     return 8;
   }
-  virtual int EXTAPI GetOption (ENCODER_OPTION eOptionId, void* pOption) {
+  virtual int EXTAPI SetOption (ENCODER_OPTION eOptionId, void* pOption) {
     EXPECT_TRUE (gThis == this);
     return 9;
+  }
+  virtual int EXTAPI GetOption (ENCODER_OPTION eOptionId, void* pOption) {
+    EXPECT_TRUE (gThis == this);
+    return 10;
   }
 };
 


### PR DESCRIPTION
Introduce `CopyLastReconFrame` API to ISVCEncoder for direct access to the last reconstructed I420 frame.