### PR TITLE
RDI-2895 RDI-2873 Save recon in bsinfo

### DIFF
--- a/codec/api/wels/codec_app_def.h
+++ b/codec/api/wels/codec_app_def.h
@@ -642,18 +642,6 @@ typedef struct {
 } SLayerBSInfo, *PLayerBSInfo;
 
 /**
-* @brief Frame bit stream info
-*/
-typedef struct {
-  int           iLayerNum;
-  SLayerBSInfo  sLayerInfo[MAX_LAYER_NUM_OF_FRAME];
-
-  EVideoFrameType eFrameType;
-  int iFrameSizeInBytes;
-  long long uiTimeStamp;
-} SFrameBSInfo, *PFrameBSInfo;
-
-/**
 *  @brief Structure for source picture
 */
 typedef struct Source_Picture_s {
@@ -667,6 +655,25 @@ typedef struct Source_Picture_s {
   bool      bPsnrU;                ///< get U PSNR for this frame
   bool      bPsnrV;                ///< get V PSNR for this frame
 } SSourcePicture;
+
+/**
+*  @brief Structure for reconstructed picture
+*/
+typedef SSourcePicture SReconPicture;
+
+/**
+* @brief Frame bit stream info
+*/
+typedef struct {
+  int           iLayerNum;
+  SLayerBSInfo  sLayerInfo[MAX_LAYER_NUM_OF_FRAME];
+
+  EVideoFrameType eFrameType;
+  int iFrameSizeInBytes;
+  long long uiTimeStamp;
+  SReconPicture *pReconPic;        ///< pointer to the reconstructed picture
+  bool bHaveRecon;                 ///< whether have reconstructed picture data
+} SFrameBSInfo, *PFrameBSInfo;
 
 /**
 * @brief Structure for bit rate info

--- a/codec/encoder/core/inc/encoder.h
+++ b/codec/encoder/core/inc/encoder.h
@@ -101,6 +101,10 @@ extern "C" void DumpDependencyRec (SPicture* pSrcPic, const char* kpFileName, co
  */
 void DumpRecFrame (SPicture* pSrcPic, const char* kpFileName, const int8_t kiDid, bool bAppend, SDqLayer* pDqLayer);
 
+/*!
+ * \brief   Copy the reconstructed picture to SFrameBSInfo structure
+ */
+void CopyReconPicToBSInfo (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, SPicture* pSrcRecPic, const SSourcePicture* pSrcPic);
 
 /*!
  * \brief   encode overall slices pData in a frame

--- a/codec/encoder/core/src/encoder.cpp
+++ b/codec/encoder/core/src/encoder.cpp
@@ -203,7 +203,7 @@ int32_t InitFunctionPointers (sWelsEncCtx* pEncCtx, SWelsSvcCodingParam* pParam,
 
   //
   WelsInitBGDFunc (pFuncList, pParam->bEnableBackgroundDetection);
-	WelsInitSCDPskipFunc (pFuncList, bScreenContent &&
+  WelsInitSCDPskipFunc (pFuncList, bScreenContent &&
                         (pParam->bEnableSceneChangeDetect) &&
                         (pEncCtx->pSvcParam->iComplexityMode < HIGH_COMPLEXITY));
 
@@ -389,7 +389,7 @@ EVideoFrameType DecideFrameType (sWelsEncCtx* pEncCtx, const int8_t kiSpatialNum
     //pEncCtx->bEncCurFrmAsIdrFlag: 1. first frame should be IDR; 2. idr pause; 3. idr request
     iFrameType = (pEncCtx->pVaa->bIdrPeriodFlag || bSceneChangeFlag
                   || pParamInternal->bEncCurFrmAsIdrFlag) ? videoFrameTypeIDR : videoFrameTypeP;
-    if ( videoFrameTypeIDR == iFrameType ) {
+    if (videoFrameTypeIDR == iFrameType) {
       WelsLog (& (pEncCtx->sLogCtx), WELS_LOG_DEBUG,
                "encoding videoFrameTypeIDR due to ( bIdrPeriodFlag %d, bSceneChangeFlag %d, bEncCurFrmAsIdrFlag %d )",
                pEncCtx->pVaa->bIdrPeriodFlag,
@@ -544,7 +544,61 @@ void DumpRecFrame (SPicture* pCurPicture, const char* kpFileName, const int8_t k
   }
 }
 
+/*!
+ * \brief   Copy the reconstructed picture to SFrameBSInfo structure
+ */
+void CopyReconPicToBSInfo (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, SPicture* pSrcRecPic, const SSourcePicture* pSrcPic) {
+  if (NULL != pFbi->pReconPic->pData[0] || NULL != pFbi->pReconPic->pData[1] || NULL != pFbi->pReconPic->pData[2]) {
+    SReconPicture* pReconPic = pFbi->pReconPic;
+    unsigned char* pReconData[3] = {pReconPic->pData[0], pReconPic->pData[1],
+                                    pReconPic->pData[2]
+                                   };
+    SWelsSPS* pSpsTmp = pCtx->pCurDqLayer->sLayerInfo.pSpsP;
+    bool bFrameCroppingFlag = pSpsTmp->bFrameCroppingFlag;
+    SCropOffset* pFrameCrop = &pSpsTmp->sFrameCrop;
 
+    const int32_t kiStrideY      = pSrcRecPic->iLineSize[0];
+    const int32_t kiLumaWidth    = bFrameCroppingFlag ? (pSrcRecPic->iWidthInPixel - ((pFrameCrop->iCropLeft +
+                                   pFrameCrop->iCropRight) << 1)) : pSrcRecPic->iWidthInPixel;
+    const int32_t kiLumaHeight   = bFrameCroppingFlag ? (pSrcRecPic->iHeightInPixel - ((pFrameCrop->iCropTop +
+                                   pFrameCrop->iCropBottom) << 1)) : pSrcRecPic->iHeightInPixel;
+    const int32_t kiChromaWidth  = kiLumaWidth >> 1;
+    const int32_t kiChromaHeight = kiLumaHeight >> 1;
+
+    pReconPic->iColorFormat = videoFormatI420;
+    pReconPic->iPicWidth    = kiLumaWidth;
+    pReconPic->iPicHeight   = kiLumaHeight;
+    pReconPic->iStride[0]   = kiStrideY;
+    pReconPic->uiTimeStamp  = pSrcPic->uiTimeStamp;
+
+    // Copy Y plane
+    if (NULL != pReconData[0]) {
+      unsigned char* pSrcY = bFrameCroppingFlag ? (pSrcRecPic->pData[0] + kiStrideY * (pFrameCrop->iCropTop << 1) +
+                             (pFrameCrop->iCropLeft << 1)) : pSrcRecPic->pData[0];
+      for (int32_t j = 0; j < kiLumaHeight; ++j) {
+        memcpy (pReconData[0] + j * kiLumaWidth, pSrcY + j * kiStrideY, kiLumaWidth);
+      }
+    }
+
+    // Copy U and V planes
+    for (int i = 1; i < 3; ++i) {
+      if (NULL == pReconData[i])
+        continue;
+      const int32_t kiStrideUV = pSrcRecPic->iLineSize[i];
+      pReconPic->iStride[i] = kiStrideUV;
+      unsigned char* pSrcUV = bFrameCroppingFlag ? (pSrcRecPic->pData[i] + kiStrideUV * pFrameCrop->iCropTop +
+                              pFrameCrop->iCropLeft)
+                              : pSrcRecPic->pData[i];
+      for (int32_t j = 0; j < kiChromaHeight; ++j) {
+        memcpy (pReconData[i] + j * kiChromaWidth, pSrcUV + j * kiStrideUV, kiChromaWidth);
+      }
+    }
+
+    pFbi->bHaveRecon = true;
+  } else {
+    pFbi->bHaveRecon = false;
+  }
+}
 
 /***********************************************************************************/
 void WelsSetMemZero_c (void* pDst, int32_t iSize) { // confirmed_safe_unsafe_usage

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3907,6 +3907,10 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
         WelsLog (pLogCtx, WELS_LOG_WARNING,
                  "WelsEncoderEncodeExt()MinCr Checking,codec bitstream size is larger than Level limitation");
     }
+
+    if (iSpatialNum == 1 && NULL != pFbi->pReconPic)
+      CopyReconPicToBSInfo (pCtx, pFbi, fsnr, pSrcPic);
+
 #ifdef ENABLE_FRAME_DUMP
     {
       DumpDependencyRec (fsnr, &pSvcParam->sDependencyLayers[iCurDid].sRecFileName[0], iCurDid,


### PR DESCRIPTION
Access to the reconstructed frame from the H.264 encoder is useful in scenarios where the application layer needs to perform further processing or analysis on the encoded video. For example, in an LCEVC (Low Complexity Enhancement Video Coding) encoder, the reconstructed frame is required to generate enhancement layers that improve visual quality. By exposing the reconstructed picture, the encoder facilitates integration with advanced video processing workflows and enables more flexible application-level control.