### PR TITLE
RDI-2895 RDI-2873  encoder: Add reconstructed frame saving to SSourcePicture

### DIFF
--- a/codec/api/wels/codec_api.h
+++ b/codec/api/wels/codec_api.h
@@ -306,7 +306,7 @@ class ISVCEncoder {
   * @param pBsInfo output bit stream
   * @return  0 - success; otherwise -failed;
   */
-  virtual int EXTAPI EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo) = 0;
+  virtual int EXTAPI EncodeFrame (SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo) = 0;
 
   /**
   * @brief  Encode the parameters from output bit stream

--- a/codec/api/wels/codec_app_def.h
+++ b/codec/api/wels/codec_app_def.h
@@ -666,6 +666,9 @@ typedef struct Source_Picture_s {
   bool      bPsnrY;                ///< get Y PSNR for this frame
   bool      bPsnrU;                ///< get U PSNR for this frame
   bool      bPsnrV;                ///< get V PSNR for this frame
+  unsigned char*  pReconData[3];   ///< plane data of reconstructed frame
+  bool      bSaveRecon;            ///< save reconstructed frame to pReconData
+  bool      bHaveRecon;            ///< whether have reconstructed frame
 } SSourcePicture;
 
 /**

--- a/codec/encoder/core/inc/extern.h
+++ b/codec/encoder/core/inc/extern.h
@@ -93,7 +93,7 @@ void WelsUninitEncoderExt (sWelsEncCtx** ppCtx);
  * \param   kpSrcPic    Source picture
  * \return  EFrameType (videoFrameTypeIDR/videoFrameTypeI/videoFrameTypeP)
  */
-int32_t WelsEncoderEncodeExt (sWelsEncCtx*, SFrameBSInfo* pFbi, const SSourcePicture* kpSrcPic);
+int32_t WelsEncoderEncodeExt (sWelsEncCtx*, SFrameBSInfo* pFbi, SSourcePicture* kpSrcPic);
 
 int32_t WelsEncoderEncodeParameterSets (sWelsEncCtx* pCtx, void* pDst);
 

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -3438,7 +3438,7 @@ EVideoFrameType PrepareEncodeFrame (sWelsEncCtx* pCtx, SLayerBSInfo*& pLayerBsIn
  * \pParam  pSrcPic         Source Picture
  * \return  EFrameType (videoFrameTypeIDR/videoFrameTypeI/videoFrameTypeP)
  */
-int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSourcePicture* pSrcPic) {
+int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, SSourcePicture* pSrcPic) {
   if (pCtx == NULL) {
     return ENC_RETURN_MEMALLOCERR;
   }
@@ -3907,6 +3907,44 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
         WelsLog (pLogCtx, WELS_LOG_WARNING,
                  "WelsEncoderEncodeExt()MinCr Checking,codec bitstream size is larger than Level limitation");
     }
+
+    if (iSpatialNum == 1 && pSrcPic->bSaveRecon && NULL != pSrcPic->pReconData[0]) {
+      SWelsSPS* pSpsTmp = pCtx->pCurDqLayer->sLayerInfo.pSpsP;
+      bool bFrameCroppingFlag = pSpsTmp->bFrameCroppingFlag;
+      SCropOffset* pFrameCrop = &pSpsTmp->sFrameCrop;
+
+      const int32_t kiStrideY      = fsnr->iLineSize[0];
+      const int32_t kiLumaWidth    = bFrameCroppingFlag ? (fsnr->iWidthInPixel - ((pFrameCrop->iCropLeft +
+          pFrameCrop->iCropRight) << 1)) : fsnr->iWidthInPixel;
+      const int32_t kiLumaHeight   = bFrameCroppingFlag ? (fsnr->iHeightInPixel - ((pFrameCrop->iCropTop +
+          pFrameCrop->iCropBottom) << 1)) : fsnr->iHeightInPixel;
+      const int32_t kiChromaWidth  = kiLumaWidth >> 1;
+      const int32_t kiChromaHeight = kiLumaHeight >> 1;
+
+      // Copy Y plane
+      unsigned char* pSrcY = bFrameCroppingFlag ? (fsnr->pData[0] + kiStrideY * (pFrameCrop->iCropTop << 1) +
+          (pFrameCrop->iCropLeft << 1)) : fsnr->pData[0];
+      for (int32_t j = 0; j < kiLumaHeight; ++j) {
+        memcpy (pSrcPic->pReconData[0] + j * kiLumaWidth, pSrcY + j * kiStrideY, kiLumaWidth);
+      }
+
+      // Copy U and V planes
+      for (int i = 1; i < 3; ++i) {
+        if (NULL == pSrcPic->pReconData[i])
+          continue;
+        const int32_t kiStrideUV = fsnr->iLineSize[i];
+        unsigned char* pSrcUV = bFrameCroppingFlag ? (fsnr->pData[i] + kiStrideUV * pFrameCrop->iCropTop +
+            pFrameCrop->iCropLeft)
+          : fsnr->pData[i];
+        for (int32_t j = 0; j < kiChromaHeight; ++j) {
+          memcpy (pSrcPic->pReconData[i] + j * kiChromaWidth, pSrcUV + j * kiStrideUV, kiChromaWidth);
+        }
+      }
+
+      pSrcPic->bHaveRecon = true;
+    }
+
+
 #ifdef ENABLE_FRAME_DUMP
     {
       DumpDependencyRec (fsnr, &pSvcParam->sDependencyLayers[iCurDid].sRecFileName[0], iCurDid,

--- a/codec/encoder/plus/inc/welsEncoderExt.h
+++ b/codec/encoder/plus/inc/welsEncoderExt.h
@@ -75,8 +75,8 @@ class CWelsH264SVCEncoder : public ISVCEncoder {
   /*
    * return: 0 - success; otherwise - failed;
    */
-  virtual int EXTAPI EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
-  virtual int        EncodeFrameInternal (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
+  virtual int EXTAPI EncodeFrame (SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
+  virtual int        EncodeFrameInternal (SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
 
   /*
    * return: 0 - success; otherwise - failed;

--- a/codec/encoder/plus/src/welsEncoderExt.cpp
+++ b/codec/encoder/plus/src/welsEncoderExt.cpp
@@ -372,7 +372,7 @@ int32_t CWelsH264SVCEncoder::Uninitialize() {
 /*
  *  SVC core encoding
  */
-int CWelsH264SVCEncoder::EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo) {
+int CWelsH264SVCEncoder::EncodeFrame (SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo) {
   if (! (kpSrcPic && m_bInitialFlag && pBsInfo)) {
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_ERROR, "CWelsH264SVCEncoder::EncodeFrame(), cmInitParaError.");
     return cmInitParaError;
@@ -401,7 +401,7 @@ int CWelsH264SVCEncoder::EncodeFrame (const SSourcePicture* kpSrcPic, SFrameBSIn
 }
 
 
-int CWelsH264SVCEncoder ::EncodeFrameInternal (const SSourcePicture*  pSrcPic, SFrameBSInfo* pBsInfo) {
+int CWelsH264SVCEncoder ::EncodeFrameInternal (SSourcePicture*  pSrcPic, SFrameBSInfo* pBsInfo) {
 
   if ((pSrcPic->iPicWidth < 16) || ((pSrcPic->iPicHeight < 16))) {
     WelsLog (&m_pWelsTrace->m_sLogCtx, WELS_LOG_ERROR, "Don't support width(%d) or height(%d) which is less than 16!",

--- a/test/api/cpp_interface_test.cpp
+++ b/test/api/cpp_interface_test.cpp
@@ -38,7 +38,7 @@ struct SVCEncoderImpl : public ISVCEncoder {
     EXPECT_TRUE (gThis == this);
     return 4;
   }
-  virtual int EXTAPI EncodeFrame (const SSourcePicture* kpSrcPic,
+  virtual int EXTAPI EncodeFrame (SSourcePicture* kpSrcPic,
                                   SFrameBSInfo* pBsInfo) {
     EXPECT_TRUE (gThis == this);
     return 5;


### PR DESCRIPTION
- Add pReconData, bSaveRecon, bHaveRecon fields to SSourcePicture
- Implement copying reconstructed YUV planes to pReconData in encoder
- Change EncodeFrame and related APIs to accept non-const SSourcePicture
- Available only when having single spatial layer