### PR TITLE
meson: expose openh264 dependency to parent subproject consumers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -216,3 +216,8 @@ pkg.generate(libopenh264,
                'and decoding. It is suitable for use in real time ' +
                'applications such as WebRTC.',
 )
+
+if meson.version().version_compare('>= 0.54.0')
+  meson.override_dependency('openh264', openh264_dep)
+endif
+


### PR DESCRIPTION
When openh264 is built as a Meson subproject (e.g. by the lynx SDK), a `dependency('openh264')` call from thr parent project fials to resolve because this project only builds the library but never registers it as a dependency. Add `meson.override_dependency()` so parent projects can consume the built library by name.

OCP-6722